### PR TITLE
Fix hive-mind resume functionality with async/await improvements

### DIFF
--- a/.hive-mind/config.json
+++ b/.hive-mind/config.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "initialized": "2025-07-17T03:49:28.570Z",
+  "initialized": "2025-07-25T00:49:56.578Z",
   "defaults": {
     "queenType": "strategic",
     "maxWorkers": 8,

--- a/claude-flow
+++ b/claude-flow
@@ -13,9 +13,9 @@ export CLAUDE_WORKING_DIR="${PROJECT_DIR}"
 # Check common locations for npm/npx installations
 
 # Development mode - use local bin
-if [ -f "/workspaces/claude-code-flow/bin/claude-flow" ]; then
+if [ -f "${PROJECT_DIR}/bin/claude-flow" ]; then
   cd "${PROJECT_DIR}"
-  exec "/workspaces/claude-code-flow/bin/claude-flow" "$@"
+  exec "${PROJECT_DIR}/bin/claude-flow" "$@"
 fi
 
 # 1. Local node_modules (npm install claude-flow)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-flow",
-  "version": "2.0.0-alpha.63",
+  "version": "2.0.0-alpha.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-flow",
-      "version": "2.0.0-alpha.63",
+      "version": "2.0.0-alpha.70",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/cli/commands/hive-mind/ps.ts
+++ b/src/cli/commands/hive-mind/ps.ts
@@ -19,9 +19,9 @@ export const psCommand = new Command('ps')
 
     try {
       const sessions = options.all
-        ? sessionManager.getActiveSessionsWithProcessInfo()
-        : sessionManager
-            .getActiveSessionsWithProcessInfo()
+        ? await sessionManager.getActiveSessionsWithProcessInfo()
+        : (await sessionManager
+            .getActiveSessionsWithProcessInfo())
             .filter((s: any) => s.status === 'active' || s.status === 'paused');
 
       if (sessions.length === 0) {

--- a/src/cli/commands/hive-mind/stop.ts
+++ b/src/cli/commands/hive-mind/stop.ts
@@ -21,7 +21,7 @@ export const stopCommand = new Command('stop')
     try {
       if (options.all) {
         // Stop all active sessions
-        const sessions = sessionManager.getActiveSessionsWithProcessInfo();
+        const sessions = await sessionManager.getActiveSessionsWithProcessInfo();
 
         if (sessions.length === 0) {
           console.log(chalk.yellow('No active sessions found'));
@@ -87,7 +87,7 @@ export const stopCommand = new Command('stop')
         console.log(chalk.green(`✓ Session ${sessionId} stopped successfully`));
       } else {
         // Interactive selection
-        const sessions = sessionManager.getActiveSessionsWithProcessInfo();
+        const sessions = await sessionManager.getActiveSessionsWithProcessInfo();
 
         if (sessions.length === 0) {
           console.log(chalk.yellow('No active sessions found'));

--- a/src/cli/simple-commands/hive-mind.js
+++ b/src/cli/simple-commands/hive-mind.js
@@ -2420,7 +2420,7 @@ function getWorkerTypeInstructions(workerType) {
 async function showSessions(flags) {
   try {
     const sessionManager = new HiveMindSessionManager();
-    const sessions = sessionManager.getActiveSessions();
+    const sessions = await sessionManager.getActiveSessions();
 
     if (sessions.length === 0) {
       console.log(chalk.gray('No active or paused sessions found'));


### PR DESCRIPTION
## Summary
- Fixed missing `await` keyword in `resumeSession()` method that was causing "sessions.forEach is not a function" error
- Added comprehensive in-memory mode support to `resumeSession()` for systems without SQLite
- Updated `getActiveSessionsWithProcessInfo()` to be properly async with await calls
- Fixed all callers of async session management methods in ps.ts and stop.ts

## Changes Made
- `src/cli/simple-commands/hive-mind/session-manager.js`:
  - Line 505: Added missing `await` before `this.getSession(sessionId)`
  - Lines 523-571: Added complete in-memory mode handling in `resumeSession()`
  - Line 945: Made `getActiveSessionsWithProcessInfo()` properly async

- `src/cli/commands/hive-mind/ps.ts`:
  - Lines 22-25: Added `await` for `getActiveSessionsWithProcessInfo()` calls

- `src/cli/commands/hive-mind/stop.ts`:
  - Line 24: Added `await` for `getActiveSessionsWithProcessInfo()` call
  - Line 90: Added `await` for `getActiveSessionsWithProcessInfo()` call

## Test Plan
- [x] Run `hive-mind init` command successfully
- [x] Test session creation and listing
- [x] Verify resume functionality works without "forEach" errors
- [x] Test both SQLite and in-memory modes
- [x] Confirm process information displays correctly

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)